### PR TITLE
Add support for loading test services

### DIFF
--- a/src/ContainerTools/Configuration/Loader.php
+++ b/src/ContainerTools/Configuration/Loader.php
@@ -59,6 +59,12 @@ class Loader
         )));
 
         $loader->load('services.' . $this->servicesFormat);
+        
+        try {
+            $loader->load('services_test.' . $this->servicesFormat);
+        } catch (InvalidArgumentException $e) {
+            // Don't do anything if the services test file can't be loaded
+        }
     }
 
     /**

--- a/src/ContainerTools/Configuration/Loader.php
+++ b/src/ContainerTools/Configuration/Loader.php
@@ -53,17 +53,26 @@ class Loader
      */
     public function into(ContainerBuilder $containerBuilder)
     {
+        $fileLocator = new FileLocator($this->serviceConfigs);
+
         $loader = new DelegatingLoader(new LoaderResolver(array(
-            new XmlFileLoader($containerBuilder, new FileLocator($this->serviceConfigs)),
-            new YamlFileLoader($containerBuilder, new FileLocator($this->serviceConfigs)),
+            new XmlFileLoader($containerBuilder, $fileLocator),
+            new YamlFileLoader($containerBuilder, $fileLocator),
         )));
 
         $loader->load('services.' . $this->servicesFormat);
-        
+
+        $testServicesFiles = 'services_test.' . $this->servicesFormat;
+        $testServiceFilesExist = true;
+
         try {
-            $loader->load('services_test.' . $this->servicesFormat);
+            $fileLocator->locate($testServicesFiles);
         } catch (InvalidArgumentException $e) {
-            // Don't do anything if the services test file can't be loaded
+            $testServiceFilesExist = false;
+        }
+
+        if ($testServiceFilesExist) {
+            $loader->load($testServicesFiles);
         }
     }
 


### PR DESCRIPTION
This PR allows having a `services_test.xml` file next to `services.xml`.

The purpose of `services_test.xml` would be overwrite service definitions.
