### PR TITLE
Add support for lazy services

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,12 @@ Instantiate a ContainerGenerator, and fetch the container from it:
 
 ContainerGenerator expects at least one services.xml file to exist, and will throw an exception if none are found.
 
+If you need to define [lazy services](http://symfony.com/doc/current/service_container/lazy_services.html), install the ProxyManager Bridge package:
+ 
+```bash
+    composer require symfony/proxy-manager-bridge
+```
+
 ## Test Services
 Sometimes it's neccessary, in a test environment, to provide mock services that replace the real services, these can be provided in services_test.xml and use the configuration switch:
 ```php

--- a/src/ContainerTools/Container/ContainerDumperFactory.php
+++ b/src/ContainerTools/Container/ContainerDumperFactory.php
@@ -1,6 +1,7 @@
 <?php
 namespace ContainerTools\Container;
 
+use Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Dumper\PhpDumper;
 
@@ -8,6 +9,11 @@ class ContainerDumperFactory
 {
     public function create(ContainerBuilder $containerBuilder)
     {
-        return new PhpDumper($containerBuilder);
+        $dumper = new PhpDumper($containerBuilder);
+        if (class_exists('\Symfony\Bridge\ProxyManager\LazyProxy\PhpDumper\ProxyDumper')) {
+            $proxyDumper = new ProxyDumper();
+            $dumper->setProxyDumper($proxyDumper);
+        }
+        return $dumper;
     }
 }


### PR DESCRIPTION
## The problem

[Defining a service as lazy](http://symfony.com/doc/current/service_container/lazy_services.html) does not have any effect, though **ocramius/proxy-manager** and **symfony/proxy-manager-bridge**  packages are installed via Composer.

## The solution
Check if "**symfony/proxy-manager-bridge**" package is installed by verifying
the existence of the `ProxyDumper` class and register it as dumper.

Please make a new release when the PR is accepted!